### PR TITLE
docs: add contributing guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # GitHub-Workflow-Standards--Assignment
+## Contributing
+- Always create a new branch for changes.
+- Open a Pull Request to merge into main.
+- Use meaningful commit messages.


### PR DESCRIPTION
### What does this PR do?
Adds a "Contributing" section in the README with guidelines for branching, PRs, and commit messages.

### Why this change?
To enforce collaboration standards. If developers push directly to main, it risks breaking the main branch, reduces review quality, and makes rollback harder.

### Risk/Impact
Low — documentation only.
